### PR TITLE
Changed synthetic property reference to getter reference.

### DIFF
--- a/src/main/kotlin/com/yoavst/jeb/utils/renaming/RenameBackendEngineImpl.kt
+++ b/src/main/kotlin/com/yoavst/jeb/utils/renaming/RenameBackendEngineImpl.kt
@@ -73,7 +73,7 @@ object RenameBackendEngineImpl : RenameBackendEngine {
         identifier: IJavaIdentifier,
         unit: IDexUnit
     ): Boolean {
-        val decompiler = decompilerCache.getOrPut(unit, unit::decompiler)
+        val decompiler = decompilerCache.getOrPut(unit, unit::getDecompiler)
         if (decompiler.setIdentifierName(identifier, renameRequest.newName)) {
             logger.debug("Renamed identifier $identifier to ${renameRequest.newName}")
             return true


### PR DESCRIPTION
Referencing synthetic properties fails to build with dependency org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31:
`JebOps/src/main/kotlin/com/yoavst/jeb/utils/renaming/RenameBackendEngineImpl.kt: (76, 63): Unsupported [reference to the synthetic extension property for a Java get/set method]`

This was apparently permitted inadvertently in the past (and appears to be at an indeterminate state of deliberate support now), so may compile properly with other versions, but referencing the getter should ensure compatibility without any side effects that I can see.  

See: https://youtrack.jetbrains.com/issue/KT-35933/Unsupported-reference-to-the-synthetic-extension-property-for-a-Java-getset-method-in-buildgradlekts


Compiled (with unrelated warnings) and tested.